### PR TITLE
Fix fable build (which hasn't worked since "Adaptify" was added)

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "adaptify": {
-      "version": "1.1.9",
+      "version": "1.2.0-prerelease2",
       "commands": [
         "adaptify"
       ]

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "hbenl.vscode-mocha-test-adapter",
+  ],
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,5 @@
 {
-    "editor.inlayHints.enabled": "offUnlessPressed"
+    "editor.inlayHints.enabled": "offUnlessPressed",
+    "mochaExplorer.files": "./build/tests/**/*.js",
+    "mochaExplorer.require": "source-map-support/register"
 }

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,41 @@
+<Project>
+    <ItemGroup>
+        <!-- Tell "dotnet watch" to ignore generated files (because changes to them were probably triggered by dotnet watch itself) -->
+        <Compile Update="**\*.g.fs" Watch="false" />
+    </ItemGroup>
+    <!--
+        Custom target which uses the Adaptify dotnet tool running in local mode.
+
+        We use this instead of the Adaptify.MSBuild target for Fable compatibility:
+        1. the Adaptify.MSBuild target:
+            a. always runs in server mode
+            b. works by generating files in the user's temp directory then adding them to the "Compile" itemgroup before
+               "CoreCompile" runs
+        2. Fable doesn't run custom targets when building - it just works out which files to build then builds them itself
+        3. the "addtoproject" option adds generated files directly to the project file, but is only supported in local mode
+
+        This target will be called automatically for the .NET build (because we set "BeforeTargets" to "CoreCompile").
+
+        Look in ./package.json to see how we call this target when necessary for the Fable build.
+    -->
+    <Target
+        Name="AdaptifyLocal"
+        BeforeTargets="CoreCompile"
+        Condition="'$(Adaptifying)' != 'true'"
+        >
+        <!-- When NOT running under NCRUNCH -->
+        <Exec
+            Condition="'$(NCRUNCH)' != '1'"
+            Command="dotnet adaptify --local --addtoproject $(MSBuildProjectFullPath)"
+            EnvironmentVariables="Adaptifying=true"
+        />
+
+        <!-- When running under NCRUNCH -->
+        <Exec
+            Condition="'$(NCRUNCH)' == '1'"
+            Command="dotnet adaptify --local --addtoproject $(NCrunchOriginalProjectPath)"
+            EnvironmentVariables="Adaptifying=true"
+            WorkingDirectory="$(NCrunchOriginalSolutionDir)"
+        />
+    </Target>
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,11 +1,10 @@
 <Project>
   <ItemGroup>
-	<PackageVersion Include="Adaptify.Core" Version="1.1.9" />
-	<PackageVersion Include="Adaptify.MSBuild" Version="1.1.9" />
+    <PackageVersion Include="Adaptify.Core" Version="1.1.9" />
 
     <PackageVersion Include="Fable.Elmish" Version="3.1.0" />
 
-	<PackageVersion Include="Expecto" Version="9.0.4" />
+    <PackageVersion Include="Expecto" Version="9.0.4" />
 
     <PackageVersion Include="Fable.Browser.Dom" Version="2.10.1" />
     <PackageVersion Include="Fable.Core" Version="4.0.0-theta-007" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,11 +2,11 @@
   <ItemGroup>
 	<PackageVersion Include="Adaptify.Core" Version="1.1.9" />
 	<PackageVersion Include="Adaptify.MSBuild" Version="1.1.9" />
-	  
-    <PackageVersion Include="Elmish" Version="3.1.0" />
 
-    <PackageVersion Include="Expecto" Version="9.0.4" />
-    
+    <PackageVersion Include="Fable.Elmish" Version="3.1.0" />
+
+	<PackageVersion Include="Expecto" Version="9.0.4" />
+
     <PackageVersion Include="Fable.Browser.Dom" Version="2.10.1" />
     <PackageVersion Include="Fable.Core" Version="4.0.0-theta-007" />
     <PackageVersion Include="Fable.Mocha" Version="2.15.0" />
@@ -17,7 +17,7 @@
     <PackageVersion Include="Hedgehog" Version="0.13.0" />
 
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    
+
     <PackageVersion Include="YoloDev.Expecto.TestSdk" Version="0.13.3" />
   </ItemGroup>
 </Project>

--- a/Ylmish.sln
+++ b/Ylmish.sln
@@ -15,6 +15,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_", "_", "{536FB20B-F8AA-49
 	ProjectSection(SolutionItems) = preProject
 		.gitignore = .gitignore
 		Directory.Build.props = Directory.Build.props
+		Directory.Build.targets = Directory.Build.targets
 		Directory.Packages.props = Directory.Packages.props
 		.config\dotnet-tools.json = .config\dotnet-tools.json
 		global.json = global.json

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "7.0.100",
+      "version": "6.0.100",
       "rollForward": "latestFeature"
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,12 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
     "camelcase": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -682,6 +688,22 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.4.tgz",
       "integrity": "sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==",
       "dev": true
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
     },
     "spawn-command": {
       "version": "0.0.2-1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -193,6 +193,95 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "concurrently": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-7.6.0.tgz",
+      "integrity": "sha512-BKtRgvcJGeZ4XttiDiNcFiRlxoAeZOseqUvyYRUp/Vtd+9p1ULmeoSqGsDA+2ivdeDFpqrJvGvmI+StKfKl5hw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "date-fns": "^2.29.1",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.0.0",
+        "shell-quote": "^1.7.3",
+        "spawn-command": "^0.0.2-1",
+        "supports-color": "^8.1.0",
+        "tree-kill": "^1.2.2",
+        "yargs": "^17.3.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "yargs": {
+          "version": "17.6.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+          "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^8.0.1",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+          "dev": true
+        }
+      }
+    },
+    "date-fns": {
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
+      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
+      "dev": true
+    },
     "debug": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -420,6 +509,12 @@
         "p-locate": "^5.0.0"
       }
     },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
     "log-symbols": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
@@ -558,6 +653,15 @@
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true
     },
+    "rxjs": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
+      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -572,6 +676,18 @@
       "requires": {
         "randombytes": "^2.1.0"
       }
+    },
+    "shell-quote": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.4.tgz",
+      "integrity": "sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==",
+      "dev": true
+    },
+    "spawn-command": {
+      "version": "0.0.2-1",
+      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
+      "integrity": "sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==",
+      "dev": true
     },
     "string-width": {
       "version": "2.1.1",
@@ -615,6 +731,18 @@
       "requires": {
         "is-number": "^7.0.0"
       }
+    },
+    "tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true
+    },
+    "tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -6,15 +6,16 @@
   "scripts": {
     "install": "dotnet restore && dotnet tool restore",
     "watch-adaptify-tests": "dotnet watch --verbose --project tests/Ylmish.Tests/Ylmish.Tests.fsproj -- msbuild Ylmish.Tests.fsproj /t:AdaptifyLocal",
-    "watch-fable-and-mocha": "dotnet fable watch tests/Ylmish.Tests/Ylmish.Tests.fsproj -o build/tests/Ylmish.Tests --run mocha build/tests/Ylmish.Tests/Ylmish.Tests.js --watch --parallel",
-    "test+watch": "concurrently --kill-others --names \"Fable/Mocha,Adaptify\" -c green,cyan \"npm:watch-fable-and-mocha\" \"npm:watch-adaptify-tests\"" 
+    "watch-fable-and-mocha": "dotnet fable watch tests/Ylmish.Tests/Ylmish.Tests.fsproj -o build/tests/Ylmish.Tests --sourceMaps --run mocha --require source-map-support/register build/tests/Ylmish.Tests/Ylmish.Tests.js --watch --parallel",
+    "test+watch": "concurrently --kill-others --names \"Fable/Mocha,Adaptify\" -c green,cyan \"npm:watch-fable-and-mocha\" \"npm:watch-adaptify-tests\""
   },
   "keywords": [],
   "author": "",
   "license": "MIT",
   "devDependencies": {
     "concurrently": "7.6.0",
-    "mocha": "8.3.2"
+    "mocha": "8.3.2",
+    "source-map-support": "0.5.21"
   },
   "dependencies": {
     "yjs": "13.5.35"

--- a/package.json
+++ b/package.json
@@ -5,12 +5,15 @@
   "type": "module",
   "scripts": {
     "install": "dotnet restore && dotnet tool restore",
-    "test+watch": "dotnet fable watch tests/Ylmish.Tests -o build/tests/Ylmish.Tests --run mocha build/tests/Ylmish.Tests/Ylmish.Tests.js --watch --parallel"
+    "watch-adaptify-tests": "dotnet watch --verbose --project tests/Ylmish.Tests/Ylmish.Tests.fsproj -- msbuild Ylmish.Tests.fsproj /t:AdaptifyLocal",
+    "watch-fable-and-mocha": "dotnet fable watch tests/Ylmish.Tests/Ylmish.Tests.fsproj -o build/tests/Ylmish.Tests --run mocha build/tests/Ylmish.Tests/Ylmish.Tests.js --watch --parallel",
+    "test+watch": "concurrently --kill-others --names \"Fable/Mocha,Adaptify\" -c green,cyan \"npm:watch-fable-and-mocha\" \"npm:watch-adaptify-tests\"" 
   },
   "keywords": [],
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "concurrently": "7.6.0",
     "mocha": "8.3.2"
   },
   "dependencies": {

--- a/src/Ylmish/Ylmish.fsproj
+++ b/src/Ylmish/Ylmish.fsproj
@@ -15,11 +15,11 @@
 	</ItemGroup>
 	<ItemGroup>
 	<Content Include="*.fsproj; *.fs; *.js" Exclude="**\*.fs.js" PackagePath="fable\" Visible="false" />
-		
+
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="FSharp.Core" />
 		<PackageReference Include="FSharp.Data.Adaptive" />
-		<PackageReference Include="Elmish" />
+		<PackageReference Include="Fable.Elmish" />
 	</ItemGroup>
 </Project>

--- a/src/Ylmish/packages.lock.json
+++ b/src/Ylmish/packages.lock.json
@@ -2,13 +2,14 @@
   "version": 2,
   "dependencies": {
     ".NETStandard,Version=v2.0": {
-      "Elmish": {
+      "Fable.Elmish": {
         "type": "Direct",
         "requested": "[3.1.0, )",
         "resolved": "3.1.0",
-        "contentHash": "AwXmBx+dIMWsUOpFjjqZ4HZ71nGE0gMpy0iEox2ZZKis/pqLrhU49qnyB+05OEWjonwS0zfAAAPchV84y6qp5w==",
+        "contentHash": "g6oAwxcKz4mIYvVlaPSrF+YoHrraJf8zpCK7cZpwtAHcbJdZkCmX9jaCYc85PaGOXywbUsulBOH5794HelUqZg==",
         "dependencies": {
-          "FSharp.Core": "4.6.2"
+          "FSharp.Core": "4.6.2",
+          "Fable.Core": "3.0.0"
         }
       },
       "FSharp.Core": {

--- a/tests/Ylmish.Tests/Ylmish.Tests.fsproj
+++ b/tests/Ylmish.Tests/Ylmish.Tests.fsproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="common\Example.fs" />
+    <Compile Include="common\Example.g.fs" />
     <Compile Include="common\Elmish.fs" />
     <Compile Include="Adaptive.Codec.fs" />
     <Compile Include="Adaptive.Index.fs" />
@@ -17,9 +18,9 @@
     <ProjectReference Include="../../src/Ylmish/Ylmish.fsproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Adaptify.MSBuild" />
+    <PackageReference Include="Adaptify.Core" />
     <PackageReference Include="Expecto" />
-	<PackageReference Include="Fable.Mocha" />
+    <PackageReference Include="Fable.Mocha" />
     <PackageReference Include="FSharp.Core" />
     <PackageReference Include="Hedgehog" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/tests/Ylmish.Tests/common/Example.g.fs
+++ b/tests/Ylmish.Tests/common/Example.g.fs
@@ -1,0 +1,67 @@
+//faeb7074-59b6-18d2-bb45-ac1b0ebca0de
+//f6dbec3f-031b-62ea-3685-40fa122835b6
+#nowarn "49" // upper case patterns
+#nowarn "66" // upcast is unncecessary
+#nowarn "1337" // internal types
+#nowarn "1182" // value is unused
+namespace rec Example
+
+open System
+open FSharp.Data.Adaptive
+open Adaptify
+open Example
+[<System.Diagnostics.CodeAnalysis.SuppressMessage("NameConventions", "*")>]
+type AdaptiveModel(value : Model) =
+    let _PropA_ = FSharp.Data.Adaptive.cval(value.PropA)
+    let _PropB_ = FSharp.Data.Adaptive.cval(value.PropB)
+    let _PropC_ =
+        let inline __arg2 (m : AdaptiveSubmodel) (v : Submodel) =
+            m.Update(v)
+            m
+        FSharp.Data.Traceable.ChangeableModelList(value.PropC, (fun (v : Submodel) -> AdaptiveSubmodel(v)), __arg2, (fun (m : AdaptiveSubmodel) -> m))
+    let _PropD_ = FSharp.Data.Adaptive.clist(value.PropD)
+    let _PropE_ = AdaptiveSubmodel(value.PropE)
+    let _PropF_ =
+        let inline __arg2 (o : System.Object) (v : Submodel) =
+            (unbox<AdaptiveSubmodel> o).Update(v)
+            o
+        let inline __arg5 (o : System.Object) (v : Submodel) =
+            (unbox<AdaptiveSubmodel> o).Update(v)
+            o
+        Adaptify.FSharp.Core.AdaptiveOption<Example.Submodel, Example.AdaptiveSubmodel, Example.AdaptiveSubmodel>(value.PropF, (fun (v : Submodel) -> AdaptiveSubmodel(v) :> System.Object), __arg2, (fun (o : System.Object) -> unbox<AdaptiveSubmodel> o), (fun (v : Submodel) -> AdaptiveSubmodel(v) :> System.Object), __arg5, (fun (o : System.Object) -> unbox<AdaptiveSubmodel> o))
+    let mutable __value = value
+    let __adaptive = FSharp.Data.Adaptive.AVal.custom((fun (token : FSharp.Data.Adaptive.AdaptiveToken) -> __value))
+    static member Create(value : Model) = AdaptiveModel(value)
+    static member Unpersist = Adaptify.Unpersist.create (fun (value : Model) -> AdaptiveModel(value)) (fun (adaptive : AdaptiveModel) (value : Model) -> adaptive.Update(value))
+    member __.Update(value : Model) =
+        if Microsoft.FSharp.Core.Operators.not((FSharp.Data.Adaptive.ShallowEqualityComparer<Model>.ShallowEquals(value, __value))) then
+            __value <- value
+            __adaptive.MarkOutdated()
+            _PropA_.Value <- value.PropA
+            _PropB_.Value <- value.PropB
+            _PropC_.Update(value.PropC)
+            _PropD_.Value <- value.PropD
+            _PropE_.Update(value.PropE)
+            _PropF_.Update(value.PropF)
+    member __.Current = __adaptive
+    member __.PropA = _PropA_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.string>
+    member __.PropB = _PropB_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.option<Microsoft.FSharp.Core.string>>
+    member __.PropC = _PropC_ :> FSharp.Data.Adaptive.alist<AdaptiveSubmodel>
+    member __.PropD = _PropD_ :> FSharp.Data.Adaptive.alist<Microsoft.FSharp.Core.string>
+    member __.PropE = _PropE_
+    member __.PropF = _PropF_ :> FSharp.Data.Adaptive.aval<Adaptify.FSharp.Core.AdaptiveOptionCase<Submodel, AdaptiveSubmodel, AdaptiveSubmodel>>
+[<System.Diagnostics.CodeAnalysis.SuppressMessage("NameConventions", "*")>]
+type AdaptiveSubmodel(value : Submodel) =
+    let _Prop0_ = FSharp.Data.Adaptive.cval(value.Prop0)
+    let mutable __value = value
+    let __adaptive = FSharp.Data.Adaptive.AVal.custom((fun (token : FSharp.Data.Adaptive.AdaptiveToken) -> __value))
+    static member Create(value : Submodel) = AdaptiveSubmodel(value)
+    static member Unpersist = Adaptify.Unpersist.create (fun (value : Submodel) -> AdaptiveSubmodel(value)) (fun (adaptive : AdaptiveSubmodel) (value : Submodel) -> adaptive.Update(value))
+    member __.Update(value : Submodel) =
+        if Microsoft.FSharp.Core.Operators.not((FSharp.Data.Adaptive.ShallowEqualityComparer<Submodel>.ShallowEquals(value, __value))) then
+            __value <- value
+            __adaptive.MarkOutdated()
+            _Prop0_.Value <- value.Prop0
+    member __.Current = __adaptive
+    member __.Prop0 = _Prop0_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.string>
+

--- a/tests/Ylmish.Tests/packages.lock.json
+++ b/tests/Ylmish.Tests/packages.lock.json
@@ -1,14 +1,14 @@
 {
   "version": 2,
   "dependencies": {
-    "net7.0": {
-      "Adaptify.MSBuild": {
+    "net6.0": {
+      "Adaptify.Core": {
         "type": "Direct",
         "requested": "[1.1.9, )",
         "resolved": "1.1.9",
-        "contentHash": "T25oj8CHxHYCBPG05Hc0S0Tux20ipWpmA6ypladKwi3+w8MVLSu0lwQOvjPmhFOxn/NNjdjqgl27n6TzKEeLWg==",
+        "contentHash": "rXTyNpEd+zqcl8BUA+lrryiIQN1PBXMebGeYtZA0shx24+ZKHUmx+LrrkJwBXj6i3n4/p8Dq0JXdAQPApOo/8A==",
         "dependencies": {
-          "Adaptify.Core": "[1.1.9]"
+          "FSharp.Data.Adaptive": "[1.2.13, 1.3.0)"
         }
       },
       "Expecto": {
@@ -181,15 +181,6 @@
           "FSharp.Data.Adaptive": "[1.2.13, )",
           "Fable.Elmish": "[3.1.0, )",
           "Fable.Yjs": "[1.0.0, )"
-        }
-      },
-      "Adaptify.Core": {
-        "type": "CentralTransitive",
-        "requested": "[1.1.9, )",
-        "resolved": "1.1.9",
-        "contentHash": "rXTyNpEd+zqcl8BUA+lrryiIQN1PBXMebGeYtZA0shx24+ZKHUmx+LrrkJwBXj6i3n4/p8Dq0JXdAQPApOo/8A==",
-        "dependencies": {
-          "FSharp.Data.Adaptive": "[1.2.13, 1.3.0)"
         }
       },
       "Fable.Browser.Dom": {

--- a/tests/Ylmish.Tests/packages.lock.json
+++ b/tests/Ylmish.Tests/packages.lock.json
@@ -177,9 +177,9 @@
       "ylmish": {
         "type": "Project",
         "dependencies": {
-          "Elmish": "[3.1.0, )",
           "FSharp.Core": "[6.0.5, )",
           "FSharp.Data.Adaptive": "[1.2.13, )",
+          "Fable.Elmish": "[3.1.0, )",
           "Fable.Yjs": "[1.0.0, )"
         }
       },
@@ -190,15 +190,6 @@
         "contentHash": "rXTyNpEd+zqcl8BUA+lrryiIQN1PBXMebGeYtZA0shx24+ZKHUmx+LrrkJwBXj6i3n4/p8Dq0JXdAQPApOo/8A==",
         "dependencies": {
           "FSharp.Data.Adaptive": "[1.2.13, 1.3.0)"
-        }
-      },
-      "Elmish": {
-        "type": "CentralTransitive",
-        "requested": "[3.1.0, )",
-        "resolved": "3.1.0",
-        "contentHash": "AwXmBx+dIMWsUOpFjjqZ4HZ71nGE0gMpy0iEox2ZZKis/pqLrhU49qnyB+05OEWjonwS0zfAAAPchV84y6qp5w==",
-        "dependencies": {
-          "FSharp.Core": "4.6.2"
         }
       },
       "Fable.Browser.Dom": {
@@ -219,6 +210,16 @@
         "requested": "[4.0.0-theta-007, )",
         "resolved": "4.0.0-theta-007",
         "contentHash": "9nDQRQfhz6/NjoXLBMqixCjRYvx8jgHAuGjJow4W0vHoFWNauPhTex+psQsw9FRRuQF2AhIwuhHoh9Tb8JoCfw=="
+      },
+      "Fable.Elmish": {
+        "type": "CentralTransitive",
+        "requested": "[3.1.0, )",
+        "resolved": "3.1.0",
+        "contentHash": "g6oAwxcKz4mIYvVlaPSrF+YoHrraJf8zpCK7cZpwtAHcbJdZkCmX9jaCYc85PaGOXywbUsulBOH5794HelUqZg==",
+        "dependencies": {
+          "FSharp.Core": "4.6.2",
+          "Fable.Core": "3.0.0"
+        }
       },
       "FSharp.Data.Adaptive": {
         "type": "CentralTransitive",


### PR DESCRIPTION
1. Get the Fable build working (which hasn't worked since "Adaptify" was added)

3. Get the tests running both via (an updated version of) the "test+watch" script and in VS Code via the "Mocha Test Explorer" extension.

   Both of these have source map support, so there are clickable links which take you to the F# files - though clicking only actually works in VS Code, presumably because the appended line and column numbers prevent the links working in the terminal.