### PR TITLE
fix: specify correct number of items to retain

### DIFF
--- a/src/Ylmish/Y.fs
+++ b/src/Ylmish/Y.fs
@@ -87,7 +87,7 @@ module Delta =
                 console.log("case 2: pos", string pos)
                 console.log("case 2: del", delta)
                 console.log("case 2: ix", index)
-                (index, pos + 1, delta) :: (index, pos, Y.Delta.Retain (pos (*+ 1 *))) :: []
+                (index, pos + 1, delta) :: (index, pos, Y.Delta.Retain (pos + 1)) :: []
             | (prevIndex, prevPos, Y.Delta.Insert (ins)) :: rest, ElementOperation.Set c
                 when index = Index.after prevIndex ->
                 console.log("case 3")

--- a/src/Ylmish/Y.fs
+++ b/src/Ylmish/Y.fs
@@ -83,11 +83,13 @@ module Delta =
                 (index, 0, delta) :: []
             | [], Delta append empty delta ->
                 console.log("case 2")
-                let pos = getPosition index// + 1
+                let pos = getPosition index
+                let toRetain = pos + 1 // +1 because the position is an index, but we need the count of items to retain
                 console.log("case 2: pos", string pos)
                 console.log("case 2: del", delta)
                 console.log("case 2: ix", index)
-                (index, pos + 1, delta) :: (index, pos, Y.Delta.Retain (pos + 1)) :: []
+                console.log("case 2: toRetain", toRetain)
+                (index, pos + 1, delta) :: (index, pos, Y.Delta.Retain toRetain) :: []
             | (prevIndex, prevPos, Y.Delta.Insert (ins)) :: rest, ElementOperation.Set c
                 when index = Index.after prevIndex ->
                 console.log("case 3")

--- a/tests/Ylmish.Tests/Y.Delta.fs
+++ b/tests/Ylmish.Tests/Y.Delta.fs
@@ -17,7 +17,7 @@ open Fable.Core.JS // console.log
 let private toIndexListDelta list =
     let delta = 
         list
-        |> List.map (fun (i, o) -> Index.at (i + 1), o)
+        |> List.map (fun (i, o) -> Index.at i, o)
         |> IndexListDelta.ofList
     let placeholders =
         if list.IsEmpty


### PR DESCRIPTION
It's necessary to add 1 to the position when retaining because it's the number of items to retain which needs to be specified, rather than the highest index.

For example, if you want to retain items with indices 0-3 you need to specify "retain 4 items".

This commit also corrects `toIndexListDelta` in "tests/Ylmish.Tests/Y.Delta.fs" by ensuring the first Index is set to Index.Zero.

With these changes, all the `Y.Delta` tests pass.