### PR TITLE
fix: remaining failing Y.Delta and Y.Text tests

### DIFF
--- a/src/Ylmish/Adaptive.Index.fs
+++ b/src/Ylmish/Adaptive.Index.fs
@@ -11,8 +11,12 @@ let generate f start count =
     List.unfold (generator count f) (0, start)
 
 let increment start i =
-    generate (fun _ i -> i) start i 
+    generate (fun _ i -> i) start i
     |> List.tryLast
     |> Option.defaultValue start
 
-let at = increment Index.zero
+let at =
+    // Index.zero seems to be roughly equivalent to a normal index of -1 i.e. it is the index which points before the 1st item.
+    //
+    // Therefore, the index of the 1st item should be after Index.zero.
+    increment (Index.after Index.zero)

--- a/src/Ylmish/Y.fs
+++ b/src/Ylmish/Y.fs
@@ -52,72 +52,140 @@ module Delta =
                 |> Option.defaultValue start
             index', ops'
 
-        let folder getItem getCount ((index, ops) : Index * IndexListDelta<'b>) delta =
+        let folder getItem getCount ((index, ops, totalCount, currentCount) : Index * IndexListDelta<'b> * int * int) delta =
             match delta with
             | Y.Delta.Retain ret ->
                 let index' = Index.increment index ret
-                index', ops
-            | Y.Delta.Delete del ->
-                let index', ops' = generate (fun _ j -> j, ElementOperation<'b>.Remove) index (del - 1)
-                index', IndexListDelta.combine ops ops'
-            | Y.Delta.Insert (ins) ->
-                let index', ops' = generate (fun i j -> j, ElementOperation<'b>.Set (getItem ins i)) index (getCount ins - 1)
-                index', IndexListDelta.combine ops ops'
+                index', ops, totalCount, currentCount + ret
 
-    let toAdaptive folder (delta : Y.Delta<'a> ResizeArray ) : IndexListDelta<'b> =
-        delta 
-        |> Seq.fold folder (Index.zero, IndexListDelta.empty)
-        |> snd
+            | Y.Delta.Delete del ->
+                let index', ops' = generate (fun _ j -> j, ElementOperation<'b>.Remove) (Index.after index) (del - 1)
+                index', IndexListDelta.combine ops ops', totalCount - del, currentCount - del
+
+            | Y.Delta.Insert ins ->
+                // If we're at the end of the clist (see note below) then we can just use Index.after the previous index.
+                //
+                // However, if we're anywhere else, we need to create an index between the previous index and the
+                // next (otherwise, instead of inserting we wll overwrite the next item).
+                //
+                // Note: here, "If we're at the end of the clist" means:
+                //
+                //   "If, when the ops generated below are performed, the first will be applied to the end of
+                //   the clist *as it exists at that time*"
+                let index' =
+                  if currentCount = totalCount then
+                    Index.after index
+                  else
+                    Index.between index (Index.after index)
+
+                let index', ops' = generate (fun i j -> j, ElementOperation<'b>.Set (getItem ins i)) index' (getCount ins - 1)
+                index', IndexListDelta.combine ops ops', totalCount + getCount ins, currentCount + getCount ins
+
+    let toAdaptive folder initialCount (delta : Y.Delta<'a> ResizeArray) : IndexListDelta<'b> =
+        delta
+        |> Seq.fold folder (Index.zero, IndexListDelta.empty, initialCount, 0)
+        |> (fun (_, list, _, _) -> list)
 
     module OfAdaptive =
-        let private (|Delta|) append empty (op : ElementOperation<'a>) =
+        let private opToDelta append empty (op: ElementOperation<'a>) =
             match op with
             | ElementOperation.Set c -> Y.Delta.Insert (append empty c)
             | ElementOperation.Remove -> Y.Delta.Delete 1
 
-        let folder getPosition (append : 'b -> 'a -> 'b) empty (state : (Index * int * Y.Delta<'b>) list) (index : Index, op : ElementOperation<'a>) =
-            match state, op with
-            | [], Delta append empty delta
-                when index = Index.zero ->
-                console.log("case 1")
-                (index, 0, delta) :: []
-            | [], Delta append empty delta ->
-                console.log("case 2")
-                let pos = getPosition index
-                let toRetain = pos + 1 // +1 because the position is an index, but we need the count of items to retain
-                console.log("case 2: pos", string pos)
-                console.log("case 2: del", delta)
-                console.log("case 2: ix", index)
-                console.log("case 2: toRetain", toRetain)
-                (index, pos + 1, delta) :: (index, pos, Y.Delta.Retain toRetain) :: []
-            | (prevIndex, prevPos, Y.Delta.Insert (ins)) :: rest, ElementOperation.Set c
-                when index = Index.after prevIndex ->
-                console.log("case 3")
-                (index, prevPos + 1, Y.Delta.Insert (append ins c)) :: rest
-            | (prevIndex, prevPos, Y.Delta.Delete (del)) :: rest, ElementOperation.Remove
-                when index = Index.after prevIndex ->
-                console.log("case 4")
-                (index, prevPos + 1, Y.Delta.Delete (del + 1)) :: rest
-            | (prevIndex, prevPos, prevDelta) :: rest, Delta append empty delta
-                when index = Index.after prevIndex ->
-                console.log("case 5")
-                (index, prevPos + 1, delta) :: (prevIndex, prevPos, prevDelta) :: rest
-            | (prevIndex, prevPos, prevDelta) :: rest, Delta append empty delta ->
-                console.log("case 6")
-                let pos = getPosition index
-                let ret = pos - prevPos
-                console.log ("rest", rest)
-                console.log ("prevDelta", prevDelta)
-                console.log ("prevPos", prevPos)
-                console.log ("pos " + string pos)
-                console.log ("ret " + string ret)
-                (index, pos, delta) :: (index, pos, Y.Delta.Retain ret) :: (prevIndex, prevPos, prevDelta) :: rest
+        type FolderState<'a> = {
+          Index: Index
+          NextPosition: int
+          Delta: Y.Delta<'a>
+        }
 
-    let ofAdaptive folder (delta : IndexListDelta<'a>) : ResizeArray<Y.Delta<'b>> =      
+        let folder
+          getPosition
+          (getLengthAdaptive: 'a -> int)
+          (append : 'b -> 'a -> 'b)
+          empty
+          (state: FolderState<'b> list)
+          (index: Index, op: ElementOperation<'a>) : FolderState<'b> list =
+            let opToDelta = opToDelta append empty
+
+            match state, op with
+            | [], op when index = Index.zero ->
+                let lengthInserted =
+                  match op with
+                  | ElementOperation.Set c  -> getLengthAdaptive c
+                  | ElementOperation.Remove -> 0
+
+                [{ Index = index; NextPosition = lengthInserted; Delta = opToDelta op }]
+
+            | [], op ->
+                let initialPosition = getPosition index
+
+                let lengthInserted =
+                  match op with
+                  | ElementOperation.Set c  -> getLengthAdaptive c
+                  | ElementOperation.Remove -> 0
+
+                let toRetain = initialPosition // we don't need to add 1 here, because we're retaining items *before* this position
+                let nextPosition = initialPosition + lengthInserted
+
+                let delta = opToDelta op
+
+                [
+                  { Index = index; NextPosition = nextPosition; Delta = delta }
+
+                  if toRetain > 0 then
+                    { Index = index; NextPosition = nextPosition; Delta = Y.Delta.Retain toRetain }
+                ]
+
+            | ({ Index = prevIndex; Delta = Y.Delta.Insert(ins) } as previous) :: rest, ElementOperation.Set c
+                when index = Index.after prevIndex ->
+                let nextPosition = previous.NextPosition + (getLengthAdaptive c)
+
+                { Index = index; NextPosition = nextPosition; Delta = Y.Delta.Insert (append ins c) } :: rest
+
+            | ({ Index = prevIndex; Delta = Y.Delta.Delete(del) } as previous) :: rest, ElementOperation.Remove
+                when index = Index.after prevIndex ->
+                { Index = index; NextPosition = previous.NextPosition + 1; Delta = Y.Delta.Delete (del + 1) } :: rest
+
+            | ({ Index = prevIndex } as previous) :: rest, op
+                when index = Index.after prevIndex ->
+                { Index = index; NextPosition = previous.NextPosition + 1; Delta = opToDelta op } :: previous :: rest
+
+            | previous:: rest, op ->
+                let pos = getPosition index
+
+                let ret =
+                    // The number to retain is the current position minus previous.NextPosition.
+                    //
+                    // For example, if we had:
+                    // [
+                    //     0, set 'a'
+                    //     1, set 'b'
+                    //     2, set 'c' <-- previous operation (should have NextPosition set to `3`)
+                    //     // 3
+                    //     // 4
+                    //     5, remove <-- current operation
+                    //     6, remove
+                    // ]
+                    //
+                    // That gives us 5 - 3 = 2 (which is correct - we want to retain the 2 items 3 and 4).
+                    pos - previous.NextPosition
+
+                [
+                  { Index = index; NextPosition = pos (* TODO - test this *); Delta = opToDelta op }
+
+                  if ret > 0 then
+                    { Index = index; NextPosition = pos (* TODO - test this *); Delta = Y.Delta.Retain ret }
+
+                  previous
+
+                  yield! rest
+                ]
+
+    let ofAdaptive folder (delta : IndexListDelta<'a>) : ResizeArray<Y.Delta<'b>> =
         delta
         |> IndexListDelta.toList
         |> List.fold folder []
-        |> List.map (fun (_,_,x) -> x)
+        |> List.map (fun (x: OfAdaptive.FolderState<_>) -> x.Delta)
         |> List.rev
         |> ResizeArray
 
@@ -125,11 +193,12 @@ module Delta =
 module Text =
     // TODO this should be private but right now there's tests for Delta.ofAdaptive/Delta.toAdaptive via the text implementation.
     module Impl =
-        let toAdaptive delta =
+        let toAdaptive initialCount delta =
             let folder = Delta.ToAdaptive.folder (fun (str : string) i -> str[i]) (fun str -> str.Length)
-            Delta.toAdaptive folder delta
+            Delta.toAdaptive folder initialCount delta
 
-        let ofAdaptive list delta =
+        let ofAdaptive (list: IndexList<_>) (delta: IndexListDelta<char>) =
+            let list', _ = IndexList.applyDelta list delta
             let folder =
                 Delta.OfAdaptive.folder
                     (fun i ->
@@ -139,17 +208,19 @@ module Text =
                         //   list', delta' = IndexList [_; _]      , IndexListDelta [Rem(0x3/0x4); Rem(0x7/0x8)]
                         //   IndexList.tryGetPosition i list  = Some _
                         //   IndexList.tryGetPosition i list' = None
-                        // Insert 
+                        // Insert
                         //   list, delta   = IndexList [a; b; d]   , IndexListDelta [[0xD/0x10]<-c]
                         //   list', delta' = IndexList [a; b; c; d], IndexListDelta [[0xD/0x10]<-c]
                         //   IndexList.tryGetPosition i list  = None
                         //   IndexList.tryGetPosition i list' = Some _
-                        let list', _ = IndexList.applyDelta list delta
                         let index =
                             IndexList.tryGetPosition i list'
-                            |> Option.orElse (IndexList.tryGetPosition i list)
+                            |> Option.orElseWith (fun () ->
+                              IndexList.tryGetPosition i list
+                            )
                             |> Option.get
                         index)
+                    (fun (_: char) -> 1)
                     (fun a b -> a + System.Char.ToString b)
                     ""
             Delta.ofAdaptive folder delta
@@ -160,15 +231,15 @@ module Text =
     //  https://github.com/krauthaufen/RemoteAdaptive/blob/master/Program.fs
     //  https://github.com/krauthaufen/RemoteAdaptive/blob/master/Utilities.fs
     //  https://discord.com/channels/611129394764840960/624645480219148299/954458318418612354
-    //  > zaoa — 03/19/2022
+    //  > zaoa â€” 03/19/2022
     //  > Can I ask why this way is prefered over AddCallback ?
-    //  > krauthaufen — 03/19/2022
+    //  > krauthaufen â€” 03/19/2022
     //  > okay, so adaptive is a so-called push/pull implementation which uses a marking-phase for eagerly marking all affected things dirty and has a separate evaluation phase conceptually. When adding a callback that evaluates things you basically "fuse" both phases and the marking needs to execute user-code (like mapping functions, etc.)
     //  > This isn't really a problem until you have dynamic dependency graphs in which case execution-order is not easy to determine anymore when a user changes multiple inputs at once. There are very sophisticated ways to solve that but (since eager evaluation wasn't really important yet) we opted for a straight-forward way of dealing with that which will, in some scenarios, perform rather slow
     //  > however you might as well use it when your task isn't very performance-critical
-    //  > zaoa — 03/19/2022
+    //  > zaoa â€” 03/19/2022
     //  > So how does the AddMarkingCallback approach differ?
-    //  > krauthaufen — 03/19/2022
+    //  > krauthaufen â€” 03/19/2022
     //  > basically the callback is very cheap and no internal value gets updated during the marking-phase that way
     //  > all the heavy-lifting is offloaded to a thread where execution order is simply dictated by the call-stack
     //  > it's also a way to allow for clean batch-changes
@@ -180,62 +251,71 @@ module Text =
     //  > we could arguably hide this implementation behind a combinator AList.observe : action : (State<'a> -> Delta<'a> -> unit) -> list : alist<'a> -> IDisposable
     // Alternatively, a different kind of wrapping:
     //  https://github.com/krauthaufen/Fable.Elmish.Adaptive/blob/master/src/Fable.React.Adaptive/AdaptiveHelpers.fs
-    let attach (atext : char clist) (ytext : Y.Text) : IDisposable =
-        let mutable sentinel = false
-        let d1 =
+    let private attach (atext : char clist) (ytext : Y.Text) : IDisposable =
+        let mutable active = false // Prevent reentrancy with a flag
+        let disposeYObserver =
             // https://docs.yjs.dev/api/delta-format
-            let f (e : Y.Text.Event) (_ : Y.Transaction) =
-                if sentinel then
-                    sentinel <- false
-                    () 
-                else
-                sentinel <- true
-                let delta' = Impl.toAdaptive e.delta
-                transact (fun () -> atext.Perform delta')
+            let observeY (e : Y.Text.Event) (_ : Y.Transaction) =
+                if not active then
+                  active <- true
+                  try
+                      let delta' = Impl.toAdaptive atext.Count e.delta
+                      transact (fun () -> atext.Perform delta')
+                  finally
+                      active <- false
 
-            ytext.observe f
+            ytext.observe observeY
             {
                 new System.IDisposable with
-                    member _.Dispose () = ytext.unobserve f
+                    member _.Dispose () = ytext.unobserve observeY
             }
 
-        let d2 = atext.AddCallback(fun list delta ->
-            if sentinel then
-                sentinel <- false
-            else
-            sentinel <- true
-            let delta' = Impl.ofAdaptive list delta
-            //match ytext.doc with
-            //| None ->
-            //    console.warn ($"\
-            //        Y.Text was not added to a Y.Doc so changes to char clist won't be applied.\n\
-            //        %A{list} %A{delta}")
-            //    sentinel <- false
-            //| Some doc ->
-            //    let delta' = Delta.ofAdaptive list delta
-            //    console.log ("got delta", delta')
-            //    doc.transact (fun tx ->
-            //        let _ = tx.meta.set ("sentinel", Sentinel.Singleton)
-            //        ytext.applyDelta delta'
-            //    )
-            ytext.applyDelta delta'
-        )
+        let disposeAdaptiveCallback =
+            let mutable initialisationCallback = true
 
-        new CompositeDisposable (d1, d2)
+            atext.AddCallback(fun list delta ->
+              if initialisationCallback then
+                // Skip the first callback - it's to perform initialisation, which we've already done
+                // before this function is called
+                initialisationCallback <- false
+              else if not active then
+                active <- true
+                try
+                  let delta' = Impl.ofAdaptive list delta
+                  //match ytext.doc with
+                  //| None ->
+                  //    console.warn ($"\
+                  //        Y.Text was not added to a Y.Doc so changes to char clist won't be applied.\n\
+                  //        %A{list} %A{delta}")
+                  //    sentinel <- false
+                  //| Some doc ->
+                  //    let delta' = Delta.ofAdaptive list delta
+                  //    console.log ("got delta", delta')
+                  //    doc.transact (fun tx ->
+                  //        let _ = tx.meta.set ("sentinel", Sentinel.Singleton)
+                  //        ytext.applyDelta delta'
+                  //    )
+                  ytext.applyDelta delta'
+                finally
+                    active <- false
+          )
+
+        new CompositeDisposable (disposeYObserver, disposeAdaptiveCallback)
 
     let ofAdaptive (atext : char clist) : Y.Text =
         let initial = System.String.Concat(atext)
         let ytext = Y.Text.Create (initial)
+
         // TODO something with these disposables
         //  At first I thought we want something like
         //  https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.conditionalweaktable-2?view=net-7.0
         //  where when the subject is cleaned-up, our subscription is disposed.
-        //  But then I realised the subject would never be cleaned-up _because_ of our subscription. 
+        //  But then I realised the subject would never be cleaned-up _because_ of our subscription.
         //  Is this useful?
         //  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef
         let _ = attach atext ytext
         ytext
-                
+
     let toAdaptive (ytext : Y.Text) : char clist =
         let atext : char clist = ytext.toString () :> _ seq |> clist
         let _ = attach atext ytext
@@ -244,9 +324,9 @@ module Text =
 [<RequireQualifiedAccess>]
 module Array =
     module Impl =
-        let toAdaptive delta =
+        let toAdaptive initialCount delta =
             let folder = Delta.ToAdaptive.folder (fun (items : Array<Y.Element option>) i -> items[i] |> Option.map Element.toAdaptive) (fun items -> items.Count)
-            Delta.toAdaptive folder delta
+            Delta.toAdaptive folder initialCount delta
 
         let ofAdaptive list delta =
             let folder =
@@ -260,7 +340,8 @@ module Array =
                             |> Option.orElse (IndexList.tryGetPosition i list)
                             |> Option.get
                         index)
-                    (fun (a : Yjs.Array<_>) b -> a.Add(b); a)
+                    (fun (_: _) -> 1) // TODO: is this right? Is this invoked with a single item, or multiple items?
+                    (fun (a: Yjs.Array<_>) b -> a.Add(b); a)
                     Array.empty
             Delta.ofAdaptive folder delta
 
@@ -271,10 +352,10 @@ module Array =
             let f (e : Y.Array.Event<Y.Element option>) (_ : Y.Transaction) =
                 if sentinel then
                     sentinel <- false
-                    () 
+                    ()
                 else
                 sentinel <- true
-                let delta' = Impl.toAdaptive e.delta
+                let delta' = Impl.toAdaptive alist.Count e.delta
                 transact (fun () -> alist.Perform delta')
 
             yarray.observe f

--- a/tests/Ylmish.Tests/Adaptive.Index.fs
+++ b/tests/Ylmish.Tests/Adaptive.Index.fs
@@ -23,11 +23,11 @@ let tests = testList "Adaptive.Index" [
         ] ""
     }
     test "at 0" {
-        Expect.equal (Index.at 0) (Index.zero) ""
+        Expect.equal (Index.at 0) (Index.after Index.zero) ""
     }
     test "at 3" {
         Expect.equal (Index.at 3) (
-            Index.after (Index.after (Index.after Index.zero))
+            Index.after (Index.after (Index.after (Index.after Index.zero)))
         ) ""
     }
     test "increment 0" {
@@ -42,6 +42,6 @@ let tests = testList "Adaptive.Index" [
         let ls = IndexList.ofList [ 'a'; 'b'; 'c' ]
         Expect.equal (ls.[0]) 'a' ""
         Expect.equal (ls.TryFind 'a' |> Option.get) (Index.after Index.zero) ""
-        // Expect.equal (ls.TryFind 'a' |> Option.get) (Index.at 0) ""
+        Expect.equal (ls.TryFind 'a' |> Option.get) (Index.at 0) ""
     }
 ]

--- a/tests/Ylmish.Tests/Y.Text.fs
+++ b/tests/Ylmish.Tests/Y.Text.fs
@@ -12,39 +12,63 @@ open Expecto
 #endif
 
 let tests = testList "Y.Text" [
-    test "ofAdaptive, atext_InsertAt()" {
-        let atext = clist [ 'a'; 'b'; 'd' ]
-        let ydoc = Y.Doc.Create ()
-        let ytext = Y.Text.ofAdaptive atext
-        let _ = ydoc.getMap("container").set("test", ytext)
+    testList "ofAdaptive" [
+        test "ofAdaptive (initialisation)" {
+            let atext = clist [ 'a'; 'b'; 'd' ]
+            let ydoc = Y.Doc.Create ()
+            let ytext = Y.Text.ofAdaptive atext
+            let _ = ydoc.getMap("container").set("test", ytext)
 
-        let _ = transact (fun () -> atext.InsertAt (2, 'c'))
+            Expect.equal (System.String.Concat atext) "abd" "atext doesn't equal expected value"
+            Expect.equal (ytext.toString()) "abd" "ytext doesn't equal expected value"
+        }
 
-        Expect.equal (System.String.Concat atext) "abcd" "equal"
-        Expect.equal (ytext.toString()) "abcd" "equal"
-    }
+        test "ofAdaptive, atext_InsertAt(): given \"abd\", insert 'c' to give \"abcd\"" {
+            let atext = clist [ 'a'; 'b'; 'd' ]
+            let ydoc = Y.Doc.Create ()
+            let ytext = Y.Text.ofAdaptive atext
+            let _ = ydoc.getMap("container").set("test", ytext)
 
-    test "ofAdaptive, ytext_insert()" {
-        let atext = clist [ 'a'; 'b'; 'd' ]
-        let ydoc = Y.Doc.Create ()
-        let ytext = Y.Text.ofAdaptive atext
-        let _ = ydoc.getMap("container").set("test", ytext)
+            let _ = transact (fun () -> atext.InsertAt (2, 'c'))
 
-        let _ = ytext.insert(2, "c")
+            Expect.equal (System.String.Concat atext) "abcd" "atext doesn't equal expected value"
+            Expect.equal (ytext.toString()) "abcd" "ytext doesn't equal expected value"
+        }
 
-        Expect.equal (System.String.Concat atext) "abcd" "equal"
-        // Expect.equal (ytext.toString()) "abcd" "equal"
-    }
+        test "ofAdaptive, ytext_insert(): given \"abd\", insert 'c' to give \"abcd\"" {
+            let atext = clist [ 'a'; 'b'; 'd' ]
+            let ydoc = Y.Doc.Create ()
+            let ytext = Y.Text.ofAdaptive atext
+            let _ = ydoc.getMap("container").set("test", ytext)
 
-    test "toAdaptive, ytext_insert()" {
-        let ydoc = Y.Doc.Create ()
-        let ytext = ydoc.getText "test"
-        let _ = ytext.insert(0, "abd")
-        let atext = Y.Text.toAdaptive ytext
+            let _ = ytext.insert(2, "c")
 
-        let _ = ytext.insert(2, "c")
+            Expect.equal (System.String.Concat atext) "abcd" "atext doesn't equal expected value"
+            Expect.equal (ytext.toString()) "abcd" "ytext doesn't equal expected value"
+        }
+    ]
 
-        Expect.equal (System.String.Concat atext) "abcd" "equal"
+    testList "toAdaptive" [
+        test "toAdaptive, (initialisation)" {
+            let ydoc = Y.Doc.Create ()
+            let ytext = ydoc.getText "test"
+            let _ = ytext.insert(0, "abd")
+            let atext = Y.Text.toAdaptive ytext
 
-    }
+            Expect.equal (System.String.Concat atext) "abd" "atext doesn't equal expected value"
+            Expect.equal (ytext.toString()) "abd" "ytext doesn't equal expected value"
+        }
+
+        test "toAdaptive, ytext_insert()" {
+            let ydoc = Y.Doc.Create ()
+            let ytext = ydoc.getText "test"
+            let atext = Y.Text.toAdaptive ytext
+
+            let _ = ytext.insert(0, "abd")
+            let _ = ytext.insert(2, "c")
+
+            Expect.equal (System.String.Concat atext) "abcd" "atext doesn't equal expected value"
+            Expect.equal (ytext.toString()) "abcd" "ytext doesn't equal expected value"
+        }
+    ]
 ]


### PR DESCRIPTION
With these changes, all the Y.Delta and Y.Text tests are passing.

However, there are quite a few assumptions about the `Index` type from `FSharp.Data.Adaptive`, which I suspect won't hold when applying changes to a document which has already been edited.

Basically, the code does a lot of generating indices based on a combination of the previous index and the current op. This could be avoided by replacing the current 2 stage process:

1. convert Y delta to Adaptive delta
2. apply the Adaptive delta to the Adaptive list
 
with:

1. iterate through the Y delta applying the appropriate changes to the Adaptive list as we go. (That way we never have to generate an instance of `Index` ourselves - `FSharp.Data.Adaptive` will take care of it for us.)

@NickDarvey maybe you've already tried that approach and it has disadvantages I've not thought of? However, I would expect that providing it was nested within a single `transact` call, it would be fine.
