### PR TITLE
chore: where sensible, share Mocha configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
     "editor.inlayHints.enabled": "offUnlessPressed",
-    "mochaExplorer.files": "./build/tests/**/*.js",
-    "mochaExplorer.require": "source-map-support/register"
+    "mochaExplorer.watch": "./build/tests/**/*.js"
 }

--- a/package.json
+++ b/package.json
@@ -3,12 +3,20 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
+
+  "mocha": {
+    "inline-diffs": true,
+    "parallel": true,
+    "require": "source-map-support/register",
+    "spec": "build/tests/Ylmish.Tests/Ylmish.Tests.js"
+  },
+
   "scripts": {
     "install": "dotnet restore && dotnet tool restore",
     "adaptify": "msbuild tests/Ylmish.Tests/Ylmish.Tests.fsproj /t:AdaptifyLocal",
     "mocha": "dotnet fable tests/Ylmish.Tests/Ylmish.Tests.fsproj -o build/tests/Ylmish.Tests --sourceMaps --run mocha",
     "watch-adaptify-tests": "dotnet watch --verbose --project tests/Ylmish.Tests/Ylmish.Tests.fsproj -- msbuild Ylmish.Tests.fsproj /t:AdaptifyLocal",
-    "watch-fable-and-mocha": "dotnet fable watch tests/Ylmish.Tests/Ylmish.Tests.fsproj -o build/tests/Ylmish.Tests --sourceMaps --run mocha --require source-map-support/register build/tests/Ylmish.Tests/Ylmish.Tests.js --watch --parallel",
+    "watch-fable-and-mocha": "dotnet fable watch tests/Ylmish.Tests/Ylmish.Tests.fsproj -o build/tests/Ylmish.Tests --sourceMaps --run mocha --watch",
     "test+watch": "concurrently --kill-others --names \"Fable/Mocha,Adaptify\" -c green,cyan \"npm:watch-fable-and-mocha\" \"npm:watch-adaptify-tests\"",
     "test": "npm run adaptify && npm run mocha"
   },


### PR DESCRIPTION
chore: where sensible, share Mocha configuration between script and VS Code test runs by moving it into the "package.json" file