### PR TITLE
fix: adaptive codec roundtrip test

### DIFF
--- a/src/Ylmish/Adaptive.Codec.fs
+++ b/src/Ylmish/Adaptive.Codec.fs
@@ -281,6 +281,8 @@ module Decoder =
         let result = (^b: (static member TryParse: 'a * byref< ^b> -> bool) element, &value)
         printfn $"a (input) is {typeof<'a>}"
         printfn $"b (output) is {typeof<'b>}"
+        printfn $"input is {element}"
+        printfn $"output is {value}"
         printfn $"parsed {result}"
         if result then Decoded.ok value
         else Decoded.error <| Error.UnexpectedType {| Actual = typeof<string>; Expected = [ typeof<'b> ]; Path = path |}

--- a/src/Ylmish/Adaptive.Codec.fs
+++ b/src/Ylmish/Adaptive.Codec.fs
@@ -275,18 +275,12 @@ module Decoder =
     let id : Decoder<'a, 'a> =
         fun (_, e) -> Decoded.ok e
 
-    /// Tries to parse a value to the inferred type using the built-in System parser.
-    let inline tryParse (path : Path, element : 'a) : Decoded<'b> =
-        let mutable value = Unchecked.defaultof< ^b>
-        let result = (^b: (static member TryParse: 'a * byref< ^b> -> bool) element, &value)
-        printfn $"a (input) is {typeof<'a>}"
-        printfn $"b (output) is {typeof<'b>}"
-        printfn $"input is {element}"
-        printfn $"output is {value}"
-        printfn $"parsed {result}"
-        if result then Decoded.ok value
-        else Decoded.error <| Error.UnexpectedType {| Actual = typeof<string>; Expected = [ typeof<'b> ]; Path = path |}
-
+    module Int32 =
+        let tryParse (path : Path, element : string) : Decoded<int32> =
+            match System.Int32.TryParse element with
+            | true, value -> Decoded.ok value
+            | false, _ -> Decoded.error <| Error.UnexpectedType {| Actual = typeof<string>; Expected = [ typeof<int32> ]; Path = path |}
+        
 module Decode = 
     module Element =        
         let value (f : Decoder<_,_>) : Decoder<_,_> = fun (path, el) ->
@@ -326,7 +320,8 @@ module Decode =
 
     let value x = Element.value Decoder.id x
 
-    let inline tryParse x = Element.value Decoder.tryParse x
+    module Int32 =
+        let tryParse x = Element.value Decoder.Int32.tryParse x
 
     let key key (f : Decoder<_,_>) : Decoder<_,_> = fun (path, el) ->
         match el with

--- a/src/Ylmish/Adaptive.Codec.fs
+++ b/src/Ylmish/Adaptive.Codec.fs
@@ -279,6 +279,9 @@ module Decoder =
     let inline tryParse (path : Path, element : 'a) : Decoded<'b> =
         let mutable value = Unchecked.defaultof< ^b>
         let result = (^b: (static member TryParse: 'a * byref< ^b> -> bool) element, &value)
+        printfn $"a (input) is {typeof<'a>}"
+        printfn $"b (output) is {typeof<'b>}"
+        printfn $"parsed {result}"
         if result then Decoded.ok value
         else Decoded.error <| Error.UnexpectedType {| Actual = typeof<string>; Expected = [ typeof<'b> ]; Path = path |}
 

--- a/tests/Ylmish.Tests/Adaptive.Codec.fs
+++ b/tests/Ylmish.Tests/Adaptive.Codec.fs
@@ -91,7 +91,7 @@ module private Example =
 
             let decode : Decoder<_,Thing> = Decode.object {
                 let! name = Decode.object.required "name" Decode.value
-                let! value = Decode.object.required "value" Decode.tryParse
+                let! value = Decode.object.required "value" Decode.Int32.tryParse
                 return {
                     name = name
                     value = value
@@ -106,7 +106,7 @@ module private Example =
 
         let decode : Decoder<_,_> = Decode.object {
             let! things = Decode.object.required "things" (Decode.list.required Things.decode)
-            let! foo = Decode.object.required "foo" Decode.tryParse
+            let! foo = Decode.object.required "foo" Decode.Int32.tryParse
             let! bar = Decode.object.required "bar" Decode.value
             return {
                 things = things

--- a/tests/Ylmish.Tests/Adaptive.Codec.fs
+++ b/tests/Ylmish.Tests/Adaptive.Codec.fs
@@ -17,13 +17,13 @@ module private Example =
     type Thing =
         {
             name  : string
-            value : int
+            value : string
         }
 
     module Thing =
         let gen = gen {
             let! name = Gen.string (Range.linear 0 255) Gen.alphaNum
-            let! value = Gen.int32 (Range.linearBounded ())
+            let! value = Gen.string (Range.linear 0 255) Gen.alphaNum
             return {
                 name = name
                 value = value
@@ -54,7 +54,7 @@ module private Example =
                 _value_.Value <- value.value
         member __.Current = __adaptive
         member __.name = _name_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.string>
-        member __.value = _value_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.int>
+        member __.value = _value_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.string>
 
     [<System.Diagnostics.CodeAnalysis.SuppressMessage("NameConventions", "*")>]
     type AdaptiveModel(value : Model) =
@@ -91,7 +91,7 @@ module private Example =
 
             let decode : Decoder<_,Thing> = Decode.object {
                 let! name = Decode.object.required "name" Decode.value
-                let! value = Decode.object.required "value" Decode.tryParse
+                let! value = Decode.object.required "value" Decode.value
                 return {
                     name = name
                     value = value
@@ -126,27 +126,19 @@ module private Decode =
         | Error e -> invalidOp e
 
 let tests = testList "Ylmish.Adaptive.Codec" [
-    // Currently failing:
-    //
-    // https://github.com/fable-compiler/Fable/issues/3328
-    //
-    // Tracking issue:
-    //
-    // https://github.com/primacydotco/Ylmish/issues/10
-    //
-    //test "roundtrips" {
-    //    let example : Example.Thing = {
-    //        name = "Example Thing"
-    //        value = 42
-    //    }
-    //    let actual =
-    //        example
-    //        |> Example.AdaptiveThing
-    //        |> Example.Codec.Things.encode
-    //        |> Decode.force Example.Codec.Things.decode
+    test "roundtrips" {
+       let example : Example.Thing = {
+           name = "Example Thing"
+           value = "42"
+       }
+       let actual =
+           example
+           |> Example.AdaptiveThing
+           |> Example.Codec.Things.encode
+           |> Decode.force Example.Codec.Things.decode
 
-    //    Expect.equal actual example ""
-    //}
+       Expect.equal actual example ""
+    }
 
     testCase "basic updates work" <| fun _ -> Property.check <| property {
         let! model = Example.Thing.gen |> Gen.map Example.AdaptiveThing


### PR DESCRIPTION
I [found a fix](https://github.com/fsprojects/FSharp.Data.Adaptive/issues/108#issuecomment-1383310843) for what was causing this test to fail.

...but, I since rewrote Adaptive.Codec so it was no longer failing for the same reason.

The failure is now:
```
$.value is of type System.String but expected one of [System.Int32]
```

1. 82d9c51692e38a39b1c19033d1cfd01778d12983 includes the smallest change to get this test passing. (that is, only supporting strings)
2. 02812434cd25366e7dd9cac7613a17748ed60f92 is trying to figure out why tryParse doesn't work