### PR TITLE
fix: roundtrip update test #11

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "inline-diffs": true,
     "parallel": true,
     "require": "source-map-support/register",
-    "spec": "build/tests/Ylmish.Tests/Ylmish.Tests.js"
+    "spec": "build/tests/Ylmish.Tests/Ylmish.Tests.js",
+    "timeout": 20000
   },
   "scripts": {
     "install": "dotnet restore && dotnet tool restore",

--- a/tests/Ylmish.Tests/Adaptive.Codec.fs
+++ b/tests/Ylmish.Tests/Adaptive.Codec.fs
@@ -178,11 +178,15 @@ let tests = testList "Ylmish.Adaptive.Codec" [
         Expect.equal (actual) (expected) ""
     }
 
+    // Currently failing:
+    //
+    // https://github.com/fable-compiler/Fable/issues/3328
+    //
     // Tracking issue:
     //
-    // https://github.com/primacydotco/Ylmish/issues/11
+    // https://github.com/primacydotco/Ylmish/issues/10
     //
-    //testCase "roundtrips updates" <| fun _ -> Property.check <| property {
+    // testCase "roundtrips updates" <| fun _ -> Property.check <| property {
     //    let! model = Example.Thing.gen |> Gen.map Example.AdaptiveThing
     //    let model' =
     //        model
@@ -203,5 +207,5 @@ let tests = testList "Ylmish.Adaptive.Codec" [
 
     //        Expect.equal value1 value2 ""
     //     )
-    //}
+    // }
 ]

--- a/tests/Ylmish.Tests/Adaptive.Codec.fs
+++ b/tests/Ylmish.Tests/Adaptive.Codec.fs
@@ -178,13 +178,9 @@ let tests = testList "Ylmish.Adaptive.Codec" [
         Expect.equal (actual) (expected) ""
     }
 
-    // Currently failing:
-    //
-    // https://github.com/fsprojects/FSharp.Data.Adaptive/issues/108
-    //
     // Tracking issue:
     //
-    // https://github.com/fsprojects/FSharp.Data.Adaptive/issues/108
+    // https://github.com/primacydotco/Ylmish/issues/11
     //
     //testCase "roundtrips updates" <| fun _ -> Property.check <| property {
     //    let! model = Example.Thing.gen |> Gen.map Example.AdaptiveThing
@@ -198,7 +194,7 @@ let tests = testList "Ylmish.Adaptive.Codec" [
     //        | Error e -> invalidOp e)
 
     //    let! updates = Example.Thing.gen |> Gen.list (Range.linear 0 100)
-
+    //    transact (fun () ->
     //    for update in updates do
     //        model.Update update
 
@@ -206,5 +202,6 @@ let tests = testList "Ylmish.Adaptive.Codec" [
     //        let value2 = AVal.force model.Current
 
     //        Expect.equal value1 value2 ""
+    //     )
     //}
 ]


### PR DESCRIPTION
I originally thought this test wasn't working because of [the previously mentioned issue in FSharp.Data.Adaptive](https://github.com/fsprojects/FSharp.Data.Adaptive/issues/108). However, it wasn't working because:
1. SRTP issue described by @BillHally in https://github.com/primacydotco/Ylmish/pull/13#pullrequestreview-1249903571
2. the updates weren't inside a FSharp.Data.Adaptive transaction (fix included here)
3. `Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. Ylmish\build\tests\Ylmish.Tests\Ylmish.Tests.js` (no fix yet)


